### PR TITLE
[008-REFACTORING] 매장등록,수정,삭제 api refactoring

### DIFF
--- a/src/main/java/com/shop/reservation/controller/ShopController.java
+++ b/src/main/java/com/shop/reservation/controller/ShopController.java
@@ -30,7 +30,9 @@ public class ShopController {
         return ResponseEntity.ok(shopService.registerShop(shop));
     }
 
-    /** 매장수정 (매장 관리자 권한) */
+    /**
+     * 매장수정 (매장 관리자 권한)
+     */
     @PutMapping
     @PreAuthorize("hasAuthority('SHOP_MANAGER')")
     public ResponseEntity<Shop> modifyShop(

--- a/src/main/java/com/shop/reservation/controller/ShopController.java
+++ b/src/main/java/com/shop/reservation/controller/ShopController.java
@@ -20,13 +20,14 @@ public class ShopController {
 
     private final ShopService shopService;
 
-    /** 매장등록 (매장 관리자 권한) */
+    /**
+     * 매장등록 (매장 관리자 권한)
+     */
     @PostMapping
     @PreAuthorize("hasAuthority('SHOP_MANAGER')")
     public ResponseEntity<Shop> registerShop(
-            @RequestBody Shop shop,
-            @AuthenticationPrincipal Member member) {
-        return ResponseEntity.ok(shopService.registerShop(shop, member));
+            @RequestBody Shop shop) {
+        return ResponseEntity.ok(shopService.registerShop(shop));
     }
 
     /** 매장수정 (매장 관리자 권한) */

--- a/src/main/java/com/shop/reservation/controller/ShopController.java
+++ b/src/main/java/com/shop/reservation/controller/ShopController.java
@@ -39,14 +39,16 @@ public class ShopController {
         return ResponseEntity.ok(shopService.modifyShop(shop, member));
     }
 
-    /** 매장삭제 (매장 관리자 권한) */
-    @DeleteMapping
+    /**
+     * 매장삭제 (매장 관리자 권한)
+     */
+    @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('SHOP_MANAGER')")
     public ResponseEntity<String> removeShop(
-            @RequestBody Shop shop,
+            @PathVariable Long id,
             @AuthenticationPrincipal Member member) {
-        Shop removedShop = shopService.removeShop(shop, member);
-        if(ObjectUtils.isEmpty(removedShop)) {
+        Shop removedShop = shopService.removeShop(id, member);
+        if (ObjectUtils.isEmpty(removedShop)) {
             throw new ShopException(ShopErrorCode.FAIL_REMOVE_SHOP);
         }
         return ResponseEntity.ok("삭제되었습니다.");

--- a/src/main/java/com/shop/reservation/exception/SignUpException.java
+++ b/src/main/java/com/shop/reservation/exception/SignUpException.java
@@ -1,30 +1,19 @@
 package com.shop.reservation.exception;
 
 import com.shop.reservation.exception.type.SignUpErrorCode;
+import lombok.Getter;
 
+@Getter
 public class SignUpException extends BaseAbstractException {
 
     private final SignUpErrorCode errorCode;
     private final String errorMessage;
+    private final int statusCode;
 
     public SignUpException(SignUpErrorCode errorCode) {
         this.errorCode = errorCode;
         this.errorMessage = errorCode.getErrorMessage();
-    }
-
-    @Override
-    public SignUpErrorCode getErrorCode() {
-        return this.errorCode;
-    }
-
-    @Override
-    public String getErrorMessage() {
-        return this.errorMessage;
-    }
-
-    @Override
-    public int getStatusCode() {
-        return errorCode.getStatusCode();
+        this.statusCode = errorCode.getStatusCode();
     }
 
 }

--- a/src/main/java/com/shop/reservation/service/ShopService.java
+++ b/src/main/java/com/shop/reservation/service/ShopService.java
@@ -27,7 +27,7 @@ public class ShopService {
      * @return 저장한 매장 객체 정보
      */
     @Transactional
-    public Shop registerShop(Shop shop, Member member) {
+    public Shop registerShop(Shop shop) {
         // 매장정보 validation check
         shopInsertValidationCheck(shop);
         // 매장정보 저장 및 반환

--- a/src/main/java/com/shop/reservation/service/ShopService.java
+++ b/src/main/java/com/shop/reservation/service/ShopService.java
@@ -50,14 +50,17 @@ public class ShopService {
 
     /**
      * 매장삭제(논리적삭제)
-     * @param shop 삭제할 매장 객체 정보
+     * @param id 삭제할 매장 ID
      * @param member 점장 객체 정보
      * @return 논리적 삭제 건 수
      */
     @Transactional
-    public Shop removeShop(Shop shop, Member member) {
+    public Shop removeShop(Long id, Member member) {
         // 매장정보 validation check
-        shopRemoveValidationCheck(shop, member);
+        shopRemoveValidationCheck(id, member);
+        // 매장정보 조회
+        Shop shop = shopRepository.findById(id)
+                .orElseThrow(() -> new ShopException(NOT_REGISTERED_SHOP));
         // delYn 수정
         shop.setDelYn("Y");
         // 매장정보 삭제 및 반환
@@ -99,13 +102,13 @@ public class ShopService {
     }
 
     // 매장삭제 validation check
-    private void shopRemoveValidationCheck(Shop shop, Member member) {
+    private void shopRemoveValidationCheck(Long id, Member member) {
         // id validation check
-        if(ObjectUtils.isEmpty(shop.getId())) {
+        if(ObjectUtils.isEmpty(id)) {
             throw new ShopException(NOT_REGISTERED_SHOP);
         }
 
-        Shop foundShop = shopRepository.findById(shop.getId())
+        Shop foundShop = shopRepository.findById(id)
                 .orElseThrow(() ->
                         new ShopException(NOT_REGISTERED_SHOP));
 


### PR DESCRIPTION
Changes
---
1. 매장등록 api 사용하지 않는 member request param 제거
2. 매장수정 api 주석변경
3.  매장삭제 api 매장정보전체를 request param으로 받지않고 매장ID만 path variable로 받기
4. 회원가입 예외처리 클래스 getter() -> Getter 어노테이션으로 대체 


Background
---
매장정보 삭제 시 사용하지 않는 매장정보를 파라미터로 받지 않고 삭제 시 필요한 매장ID(PK)만 전달받아 삭제하는 것이 더 옳은 방향이라고 생각해 변경했습니다.